### PR TITLE
fix mdbook config

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -2,7 +2,7 @@
 title = "学习 Zig"
 description = "Learning Zig 中文翻译"
 authors = ["ZigCC"]
-language = "cn"
+language = "zh-CN"
 multilingual = false
 src = "."
 


### PR DESCRIPTION
the language code for simplified Chinese should be `zh-CN`. This code is a combination of the ISO 639-1 two-letter language code for Chinese (zh) and the ISO 3166-1 alpha-2 country code for China (CN),